### PR TITLE
Use sharp instead of svg2png and added several sizes for ios.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,45 +21,70 @@ gulp.task('default', [], function() {
 
 This will create all icons in the folder `images/`.
 
+If you want to customize the filenames or sizes of the icons, pass an object to mobileIcons(SIZES):
+```javascript
+gulp.task('build_icons', [], function() {
+    const MY_SIZES = {
+        'icon-57': { width: 57, height: 57 },
+        'icon-57@2x': { width: 114, height: 114 },
+        'icon-72': { width: 72, height: 72 }
+    }
+    gulp.src('icon.svg')
+        .pipe(mobileIcons(MY_SIZES))
+        .pipe(gulp.dest('images'));
+});
+```
+
 ### Cordova / PhoneGap
 
 Add the following to your `config.xml` to use the icons in a Cordova/PhoneGap application:
 
 ```html
 <platform name="ios">
-    <!-- App icon -->
-    <icon src="images/ios-57.png"      width="57"  height="57"/>
-    <icon src="images/ios-57@2x.png"   width="114" height="114"/>
-    <icon src="images/ios-72.png"      width="72"  height="72"/>
-    <icon src="images/ios-72@2x.png"   width="144" height="144"/>
-    <icon src="images/ios-60.png"      width="60"  height="60"/>
-    <icon src="images/ios-60@2x.png"   width="120" height="120"/>
-    <icon src="images/ios-60@3x.png"   width="180" height="180"/>
-    <icon src="images/ios-76.png"      width="76"  height="76"/>
-    <icon src="images/ios-76@2x.png"   width="152" height="152"/>
-    <icon src="images/ios-76@3x.png"   width="228" height="228"/>
-    <icon src="images/ios-83.5@2x.png" width="167" height="167"/>
-
-    <!-- Spotlight -->
-    <icon src="images/ios-50@2x.png"   width="100" height="100"/>
-    <icon src="images/ios-40.png"      width="40"  height="40"/>
-    <icon src="images/ios-40@2x.png"   width="80"  height="80"/>
-    <icon src="images/ios-40@3x.png"   width="120" height="120"/>
-
-    <!-- Settings -->
-    <icon src="images/ios-29.png"      width="29"  height="29"/>
-    <icon src="images/ios-29@2x.png"   width="58"  height="58"/>
-    <icon src="images/ios-29@3x.png"   width="87"  height="87"/>
-
-    <!-- Navigation bar and toolbar -->
-    <icon src="images/ios-22.png"      width="22"  height="22"/>
-    <icon src="images/ios-22@2x.png"   width="44"  height="44"/>
-    <icon src="images/ios-22@3x.png"   width="66"  height="66"/>
-
-    <!-- Tab bar -->
-    <icon src="images/ios-25.png"      width="25"  height="25"/>
-    <icon src="images/ios-25@2x.png"   width="50"  height="50"/>
-    <icon src="images/ios-25@3x.png"   width="75"  height="75"/>
+    <!-- iOS 8.0+ -->
+    <!-- iPhone 6 Plus  -->
+    <icon src="images/ios-60@3x.png" width="180" height="180" />
+    <!-- iOS 7.0+ -->
+    <!-- iPhone / iPod Touch  -->
+    <icon src="images/ios-60.png" width="60" height="60" />
+    <icon src="images/ios-60@2x.png" width="120" height="120" />
+    <!-- iPad -->
+    <icon src="images/ios-76.png" width="76" height="76" />
+    <icon src="images/ios-76@2x.png" width="152" height="152" />
+    <!-- Spotlight Icon -->
+    <icon src="images/ios-40.png" width="40" height="40" />
+    <icon src="images/ios-40@2x.png" width="80" height="80" />
+    <icon src="images/ios-40@3x.png" width="120" height="120" /> <!-- same as 60@2x -->
+    <!-- iOS 6.1 -->
+    <!-- iPhone / iPod Touch -->
+    <icon src="images/ios-57.png" width="57" height="57" />
+    <icon src="images/ios-57@2x.png" width="114" height="114" />
+    <!-- iPad -->
+    <icon src="images/ios-20.png" width="20" height="20" />
+    <icon src="images/ios-29.png" width="29" height="29" />
+    <icon src="images/ios-72.png" width="72" height="72" />
+    <icon src="images/ios-72@2x.png" width="144" height="144" />
+    <!-- iPhone Spotlight and Settings Icon -->
+    <icon src="images/ios-29.png" width="29" height="29" />
+    <icon src="images/ios-29@2x.png" width="58" height="58" />
+    <icon src="images/ios-29@3x.png" width="87" height="87" />
+    <icon src="images/ios-20@2x.png" width="40" height="40" /> <!-- same as 40@1x -->
+    <icon src="images/ios-20@3x.png" width="60" height="60" /> <!-- same as 60@1x -->
+    <!-- iPad Spotlight and Settings Icon -->
+    <icon src="res/ios/icon-50.png" width="50" height="50" />
+    <icon src="images/ios-50@2x.png" width="100" height="100" />
+    <!-- iPad Pro -->
+    <icon src="images/ios-83.5@2x.png" width="167" height="167" />
+    <!-- Apple Watch -->
+    <icon src="images/ios-24.png" width="24" height="24" />
+    <icon src="images/ios-24@2x.png" width="48" height="48" />
+    <icon src="images/ios-27.5@2x.png" width="55" height="55" />
+    <icon src="images/ios-44@2x.png" width="88" height="88" />
+    <icon src="images/ios-86@2x.png" width="172" height="172" />
+    <icon src="images/ios-98@2x.png" width="196" height="196" />
+    <icon src="images/ios-108@2x.png" width="216" height="216" />
+    <!-- iTunes Marketing Image -->
+    <icon src="images/ios-1024.png" width="1024" height="1024" />
 </platform>
 
 <platform name="android">

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ gulp.task('default', [], function() {
 
 This will create all icons in the folder `images/`.
 
-If you want to customize the filenames or sizes of the icons, pass an object to mobileIcons(SIZES):
+If you want to customize the filenames or sizes of the icons, pass an object to mobileIcons(MY_SIZES):
 ```javascript
 gulp.task('build_icons', [], function() {
     const MY_SIZES = {

--- a/index.js
+++ b/index.js
@@ -53,6 +53,7 @@ const SIZES = {
 	// iPad retina (iOS 5 + iOS 6)
 	'ios-50@2x'  : { width: 100, height: 100 },
 	// iPhone + iPad (non-retina)
+	'ios-50'     : { width:  50, height:  50 },
 	'ios-40'     : { width:  40, height:  40 },
 	// iPhone 6s, iPhone 6, iPhone SE, iPad Pro, iPad, iPad mini
 	'ios-40@2x'  : { width:  80, height:  80 },
@@ -68,6 +69,8 @@ const SIZES = {
 	'ios-29@3x'  : { width:  87, height:  87 },
 
 	/* Navigation bar and toolbar */
+	// iPad
+	'ios-20'     : { width:  20, height:  20 },
 	// iPhone + iPad (non-retina)
 	'ios-22'     : { width:  22, height:  22 },
 	// iPhone 6s, iPhone 6, iPhone SE, iPad Pro, iPad, iPad mini
@@ -82,6 +85,15 @@ const SIZES = {
 	'ios-25@2x'  : { width:  50, height:  50 },
 	// iPhone 6s Plus, iPhone 6 Plus
 	'ios-25@3x'  : { width:  75, height:  75 },
+
+	// Apple Watch
+	'ios-24'   :   { width: 24,  height: 24},
+	'ios-24@2x':   { width: 48,  height: 48},
+	'ios-27.5@2x': { width: 55,  height: 55},
+	'ios-44@2x':   { width: 88,  height: 88},
+	'ios-86@2x':   { width: 172, height: 172},
+	'ios-98@2x':   { width: 196, height: 196},
+	'ios-108@2x':  { width: 216, height: 216},
 
 	// iOS marketing icon
 	'ios-marketing': { width: 1024, height: 1024 },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Gulp plugin that creates PNG icons for iOS and Android based on a SVG image",
   "dependencies": {
     "gulp-util": "^3.0.7",
-    "svg2png": "^4.1.1",
+    "sharp": "^0.28.3",
     "through2": "^2.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Use sharp instead of svg2png. Sharp allows setting background color and removing transparency.
Also added apple watch sizes and documented.

Fixes #8 